### PR TITLE
Initial version of CI for RSSingle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-# to be completed once macOS builds fixed
+  # to be completed once macOS builds fixed
   create-and-publish-release:
     needs: build-and-check
     if: startsWith(github.ref, 'refs/tags/') && success()
@@ -34,8 +34,9 @@ jobs:
       matrix:
         # `--windowed` is for macOS, and `--onefile` is for other OSes.
         pyinstaller-type: ['--windowed', '--onefile']
-    runs-on: ubuntu-latest
-    name: Builder for Python all-in-one executables, published on a releases
+        runner: ["macos-latest", "windows-latest", "ubuntu-latest"]
+    runs-on: ${{ matrix.runner }}
+    name: Builder for Python all-in-one executables, published on a release.
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -48,7 +49,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install pyinstaller
           pip install -r requirements.txt
-      - name: Build RSSingle
-        run: pyinstaller ${{ matrix.pyinstaller-type }} ./rssingle.py
+      - name: Build RSSingle (Windows, Linux)
+        if: ${{ matrix.runner != 'macos-latest' }}
+        run: pyinstaller --onefile ./rssingle.py
+      - name: Build RSSingle (macOS)
+        if: ${{ matrix.runner == 'macos-latest' }}
+        run: pyinstaller --windowed ./rssingle.py
       - name: List artifacts for finishing this action
         run: find ./dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI workflow for RSSingle
+
+on: [push, pull_request]
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          pip install -r requirements.txt
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+# to be completed once macOS builds fixed
+  create-and-publish-release:
+    needs: build-and-check
+    if: startsWith(github.ref, 'refs/tags/') && success()
+    strategy:
+      matrix:
+        # `--windowed` is for macOS, and `--onefile` is for other OSes.
+        pyinstaller-type: ['--windowed', '--onefile']
+    runs-on: ubuntu-latest
+    name: Builder for Python all-in-one executables, published on a releases
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r requirements.txt
+      - name: Build RSSingle
+        run: pyinstaller ${{ matrix.pyinstaller-type }} ./rssingle.py
+      - name: List artifacts for finishing this action
+        run: find ./dist/


### PR DESCRIPTION
Hi @tanrax!

As part of our new collaboration, I've made an initial version for automated CI for RSSingle.

It needs macOS to work first, so I've commented out a draft version of the `pyinstaller` aspect, so I'll make this PR a draft for now when we can discuss further, preferably in a GH issue for transparency (unless you want it private?), but this workflow tests on PRs and pushes to any branch, with flake8 across multiple Python versions. The pyinstaller aspect only runs if the flake8 check passes.

What do you think?

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>