### PR TITLE
Add Dependabot dependency GH support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This commit adds support for Dependabot, which will alert the maintainer when things are out of date, including GH Actions and Python packages.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>