### PR TITLE
Add Docker support for RSSingle, and a workflow for builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/LICENSE
+/README.md
+/rssingle.png
+/Dockerfile
+/config.yml

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI workflow for RSSingle"]
     types: [completed]
-    branches: [main]
+    branches: [master]
   
 jobs:
   build-and-push-container-image:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,44 @@
+name: Container image builder for RSS single
+
+on:
+  workflow_run:
+    workflows: ["CI workflow for RSSingle"]
+    types: [completed]
+    branches: [main]
+  
+jobs:
+  build-and-push-container-image:
+    name: Build and push container image to Docker Hub and GHCR.io
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Build container image
+        id: build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: tanrax/rssingle
+          tags: latest
+          containerfiles: Dockerfile
+
+      - name: Push container image to Docker Hub
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build.outputs.image }}
+          tags: ${{ steps.build.outputs.tags }}
+          registry: docker.io
+          username: tanrax
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Push container image to GHCR.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build.outputs.image }}
+          tags: ${{ steps.build.outputs.tags }}
+          registry: ghcr.io
+          username: tanrax
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+          

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker.io/python:3.8-buster AS base
+
+FROM base AS build
+
+WORKDIR /work
+
+COPY . .
+
+RUN pip3 install pyinstaller
+
+RUN pip3 install -r /work/requirements.txt
+RUN pyinstaller --onefile /work/rssingle.py
+
+FROM docker.io/python:3.8-buster AS app
+
+COPY --from=build /work/dist/rssingle /rssingle
+
+ENTRYPOINT ["/rssingle"]


### PR DESCRIPTION
This commit adds a Dockerfile, .dockerignore, and a GH Action for pushing container images to - and this is by default, other registries can be used - Docker Hub (you need to generate a token and install it in the repo), and GitHub Registry, which doesn't require a manual token.

The workflow won't build until #3 is merged, as it relies on successful builds from that workflow before a container image is pushed. Once we use unit tests, this will ensure container images aren't broken when pushed to a remote registry.

I have marked this PR as draft for that reason.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>