### PR TITLE
Explicitly define the return type of get_url_from_feed(config)

### DIFF
--- a/rssingle.py
+++ b/rssingle.py
@@ -45,7 +45,7 @@ def setup_logging() -> None:
     return None
 
 
-def get_url_from_feed(config):
+def get_url_from_feed(config) -> str:
     """
     This function returns the URL from a feed.
     """


### PR DESCRIPTION
This commit explicitly defines the return type of the get_url_from_feed(config) function.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>