### PR TITLE
feat(CI/dependabot): Group Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      gh-actions-deps:
+        patterns:
+          - "*"
       
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      python-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
To reduce maintainer workload, I've made this PR for Dependabot to automatically group related PRs together into one PR.

We could also enable a workflow to automatically merge Dependabot PRs, on the condition that the code continues to compile and produce a unified RSS XML feed.